### PR TITLE
Feature: Allow multiple sets of dynamics parameters

### DIFF
--- a/src/kymograph_synthesis/params/dynamics_params.py
+++ b/src/kymograph_synthesis/params/dynamics_params.py
@@ -46,7 +46,7 @@ def antero_var_default_factory(normal_std: PositiveFloat):
     return inner
 
 
-def transition_matrix_default_factory(data: dict[str:Any]) -> TransitionMatrixType:
+def transition_matrix_default_factory(data: dict[str, Any]) -> TransitionMatrixType:
     values = np.random.rand(3, 3)
     # unidirectional particles do not transition
     if data["particle_behaviour"] == "unidirectional":
@@ -75,15 +75,14 @@ class DynamicsParams(BaseModel):
 
     model_config = ConfigDict(validate_assignment=True, validate_default=True)
 
-    n_steps: PositiveInt = Field(default_factory=lambda: np.random.randint(64, 128))
-    """The number of simulation steps in the dynamics simulation."""
-
     particle_density: PositiveFloat = Field(
         default_factory=lambda: np.random.uniform(1, 12)
     )
     """Average particle density. Units are number of particles per path."""
 
-    retro_speed_mode: PositiveFloat = Field(default_factory=lambda: np.random.uniform(0.5, 6))
+    retro_speed_mode: PositiveFloat = Field(
+        default_factory=lambda: np.random.uniform(0.5, 6)
+    )
     """
     Mode of particle speed in the retrograde direction, modeled by a log-normal 
     distribution. Units are percentage of path per simulation time step.
@@ -113,7 +112,9 @@ class DynamicsParams(BaseModel):
     distribution.
     """
 
-    velocity_noise_var: PositiveFloat = Field(default_factory=lambda: np.random.uniform(0, 0.4))
+    velocity_noise_var: PositiveFloat = Field(
+        default_factory=lambda: np.random.uniform(0, 0.4)
+    )
     """
     Variance of the velocity noise, modeled by a Gaussian distribution. Units are 
     percentage of path per simulation time step.
@@ -131,19 +132,10 @@ class DynamicsParams(BaseModel):
     )
     """Variance of the particle intensities, modeled by a log-normal distribution."""
 
-    fluorophore_halflife_mode: PositiveFloat = Field(
-        default_factory=lambda data: np.random.uniform(
-            data["n_steps"] * 0.5, data["n_steps"] * 1.5
-        )
-    )
+    fluorophore_halflife_mode: PositiveFloat
     """Mode of particle intensity half-life, modeled by a log-normal distribution."""
 
-    fluorophore_halflife_var: PositiveFloat = Field(
-        default_factory=lambda data: np.random.uniform(
-            data["n_steps"] * 0.5 / 10, data["n_steps"] * 1.5 / 10
-        )
-        ** 2
-    )
+    fluorophore_halflife_var: PositiveFloat
     """
     Variance of the paticle intensity half-life, modeled by a log-normal distribution.
     """

--- a/src/kymograph_synthesis/pipeline/pipeline.py
+++ b/src/kymograph_synthesis/pipeline/pipeline.py
@@ -46,7 +46,9 @@ class Pipeline:
         self.generate_ground_truth_output: Optional[GenerateGroundTruthOutput] = None
 
     def run(self):
-        self.dynamics_sim_output = simulate_dynamics(self.params.dynamics)
+        self.dynamics_sim_output = simulate_dynamics(
+            self.params.dynamics, self.params.n_steps
+        )
         # (alias to avoid too long line)
         particle_fluorophore_count = self.dynamics_sim_output[
             "particle_fluorophore_count"

--- a/src/kymograph_synthesis/pipeline/steps/simulate_dynamics.py
+++ b/src/kymograph_synthesis/pipeline/steps/simulate_dynamics.py
@@ -1,9 +1,11 @@
 from typing import TypedDict
+from collections.abc import Sequence
 
 import numpy as np
 from numpy.typing import NDArray
 from ...params import DynamicsParams
 from ...dynamics import create_particle_simulators, run_dynamics_simulation
+from ...dynamics.particle_simulator.particle_simulator import ParticleSimulator
 
 
 class DynamicsSimOutput(TypedDict):
@@ -14,18 +16,32 @@ class DynamicsSimOutput(TypedDict):
 
 
 def simulate_dynamics(
-    params: DynamicsParams,
-) -> tuple[NDArray[np.float_], NDArray[np.float_]]:
-    dynamics_rng = np.random.default_rng(seed=params.seed)
-    particles = create_particle_simulators(
-        **params.model_dump(exclude=["seed", "particle_behaviour"]), rng=dynamics_rng
-    )
-    particle_positions, particle_fluorophore_count, particle_states = (
-        run_dynamics_simulation(params.n_steps, particles)
-    )
+    params: DynamicsParams | Sequence[DynamicsParams], n_steps: int
+) -> DynamicsSimOutput:
+    if isinstance(params, DynamicsParams):
+        params = [params]
+
+    particles: list[ParticleSimulator]
+    all_positions: list[NDArray] = []
+    all_fluorophore_count: list[NDArray] = []
+    all_states: list[NDArray] = []
+    for param_set in params:
+        dynamics_rng = np.random.default_rng(seed=param_set.seed)
+        particles = create_particle_simulators(
+            n_steps=n_steps,
+            **param_set.model_dump(exclude={"seed", "particle_behaviour"}),
+            rng=dynamics_rng
+        )
+        particle_positions, particle_fluorophore_counts, particle_states = (
+            run_dynamics_simulation(n_steps, particles)
+        )
+        all_positions.append(particle_positions)
+        all_fluorophore_count.append(particle_fluorophore_counts)
+        all_states.append(particle_states)
+
     return DynamicsSimOutput(
-        n_steps=params.n_steps,
-        particle_positions=particle_positions,
-        particle_fluorophore_count=particle_fluorophore_count,
-        particle_states=particle_states,
+        n_steps=n_steps,
+        particle_positions=np.concatenate(all_positions, axis=1),
+        particle_fluorophore_count=np.concatenate(all_fluorophore_count, axis=1),
+        particle_states=np.concatenate(all_states, axis=1),
     )

--- a/src/scripts/generate_bidirectional_examples.py
+++ b/src/scripts/generate_bidirectional_examples.py
@@ -1,0 +1,107 @@
+from typing import Optional
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+from kymograph_synthesis.params import Params
+from kymograph_synthesis.pipeline import Pipeline
+
+
+def main(output_dir: Path, n_kymographs: int, seed: Optional[int]):
+
+    if not output_dir.is_dir():
+        raise NotADirectoryError(f"'{output_dir}' is not a directory.")
+    rng = np.random.default_rng(seed=seed)
+
+    for _ in range(n_kymographs):
+
+        params = Params.model_validate(
+            {
+                "dynamics": {
+                    "particle_behaviour": "bidirectional",
+                    "particle_density": rng.uniform(1, 8),
+                    "antero_speed_mode": rng.uniform(1, 3),
+                    "antero_speed_var": rng.uniform(0.00005, 0.00015),
+                    "retro_speed_mode": rng.uniform(1, 3),
+                    "retro_speed_var": rng.uniform(0.00005, 0.00015),
+                    "velocity_noise_var": rng.uniform(0.01**2, 0.05**2),
+                    "fluorophore_count_mode": rng.uniform(200, 600),
+                    "fluorophore_count_var": rng.uniform(100**2, 300**2),
+                    "transition_matrix": {
+                        "anterograde": {
+                            "anterograde": 0.7,
+                            "stationary": 0.3,
+                            "retrograde": 0,
+                        },
+                        "stationary": {
+                            "anterograde": 0.03,
+                            "stationary": 0.95,
+                            "retrograde": 0.02,
+                        },
+                        "retrograde": {
+                            "anterograde": 0,
+                            "stationary": 0.3,
+                            "retrograde": 0.7,
+                        },
+                    },
+                },
+                "rendering": {
+                    "static_distributions": [
+                        {
+                            "name": "simplex_noise",
+                            "max_fluorophore_count_per_nm3": rng.uniform(0.005, 0.03),
+                            "noise_scales": [
+                                rng.uniform(0.25, 0.75),
+                                rng.uniform(1, 1.5),
+                            ],
+                            "scale_weights": [rng.random(), rng.random()],
+                        }
+                    ],
+                    "imaging": {
+                        "exposure_ms": 100,
+                        "truth_space": {
+                            "shape": [24, 64, 512],
+                            "scale": [0.04, 0.02, 0.02],
+                        },
+                        "detector": {
+                            "camera_type": "CCD",
+                            "read_noise": 6,
+                            "gain": 60,
+                            "offset": 600,
+                        },
+                    },
+                },
+            }
+        )
+        if seed is not None:
+            params.dynamics.seed = seed
+            params.rendering.static_distributions[0].seed = seed
+            params.rendering.imaging.settings.random_seed = seed
+        pipeline = Pipeline(params, out_dir=output_dir)
+        pipeline.run()
+        pipeline.save()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--dir", "-d", type=Path, required=True, help="Directory to save outputs to."
+    )
+    parser.add_argument(
+        "-n",
+        dest="n_kymographs",
+        type=int,
+        required=True,
+        help="The number of kymographs to create.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        required=False,
+        default=None,
+        help="A seed for reproducibility",
+    )
+    args = parser.parse_args()
+
+    main(output_dir=args.dir, n_kymographs=args.n_kymographs, seed=args.seed)

--- a/src/scripts/generate_dset_1.py
+++ b/src/scripts/generate_dset_1.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import numpy as np
 
-from kymograph_synthesis.params import Params
+from kymograph_synthesis.params import Params, DynamicsParams
 from kymograph_synthesis.pipeline import Pipeline
 
 
@@ -13,45 +13,61 @@ def main(output_dir: Path, n_kymographs: int, seed: Optional[int]):
     rng = np.random.default_rng(seed=seed)
 
     for _ in range(n_kymographs):
-
-        params = Params(
-            dynamics={
-                "particle_behaviour": "unidirectional",
-                "particle_density": rng.uniform(1, 8),
-                "antero_speed_mode": rng.uniform(1, 3),
-                "antero_speed_var": rng.uniform(0.00005, 0.00015),
-                "retro_speed_mode": rng.uniform(1, 3),
-                "retro_speed_var": rng.uniform(0.00005, 0.00015),
-                "velocity_noise_var": rng.uniform(0.01**2, 0.1**2),
-                "fluorophore_count_mode": rng.uniform(200, 600),
-                "fluorophore_count_var": rng.uniform(100**2, 300**2),
-            },
-            rendering={
-                "static_distributions": [
-                    {
-                        "name": "simplex_noise",
-                        "max_fluorophore_count_per_nm3": rng.uniform(0.005, 0.03),
-                        "noise_scales": [rng.uniform(0.25, 0.75), rng.uniform(1, 1.5)],
-                        "scale_weights": [rng.random(), rng.random()],
-                    }
-                ],
-                "imaging": {
-                    "exposure_ms": 100,
-                    "truth_space": {
-                        "shape": [24, 64, 512],
-                        "scale": [0.04, 0.02, 0.02],
-                    },
-                    "detector": {
-                        "camera_type": "CCD",
-                        "read_noise": 6,
-                        "gain": 60,
-                        "offset": 600,
+        n_steps = np.random.randint(64, 128)
+        params = Params.model_validate(
+            {
+                "n_steps": n_steps,
+                "dynamics": {
+                    "particle_behaviour": "unidirectional",
+                    "particle_density": rng.uniform(1, 8),
+                    "antero_speed_mode": rng.uniform(1, 3),
+                    "antero_speed_var": rng.uniform(0.00005, 0.00015),
+                    "retro_speed_mode": rng.uniform(1, 3),
+                    "retro_speed_var": rng.uniform(0.00005, 0.00015),
+                    "velocity_noise_var": rng.uniform(0.01**2, 0.1**2),
+                    "fluorophore_count_mode": rng.uniform(200, 600),
+                    "fluorophore_count_var": rng.uniform(100**2, 300**2),
+                    "fluorophore_halflife_mode": rng.uniform(
+                        n_steps * 0.5, n_steps * 1.5
+                    ),
+                    "fluorophore_halflife_var": rng.uniform(
+                        n_steps * 0.5 / 10, n_steps * 1.5 / 10
+                    ),
+                },
+                "rendering": {
+                    "static_distributions": [
+                        {
+                            "name": "simplex_noise",
+                            "max_fluorophore_count_per_nm3": rng.uniform(0.005, 0.03),
+                            "noise_scales": [
+                                rng.uniform(0.25, 0.75),
+                                rng.uniform(1, 1.5),
+                            ],
+                            "scale_weights": [rng.random(), rng.random()],
+                        }
+                    ],
+                    "imaging": {
+                        "exposure_ms": 100,
+                        "truth_space": {
+                            "shape": [24, 64, 512],
+                            "scale": [0.04, 0.02, 0.02],
+                        },
+                        "detector": {
+                            "camera_type": "CCD",
+                            "read_noise": 6,
+                            "gain": 60,
+                            "offset": 600,
+                        },
                     },
                 },
-            },
+            }
         )
         if seed is not None:
-            params.dynamics.seed = seed
+            if isinstance(params.dynamics, DynamicsParams):
+                params.dynamics.seed = seed
+            else:
+                for param_set in params.dynamics:
+                    param_set.seed = seed
             params.rendering.static_distributions[0].seed = seed
             params.rendering.imaging.settings.random_seed = seed
         pipeline = Pipeline(params, out_dir=output_dir)


### PR DESCRIPTION
This is to allow for multiple sets of transition matrices, this means that we can have particles that will only change between the stationary state and anterograde direction plus particles that will only change between the stationary state an the retrograde direction.

## Changes
- the `dynamics` field in the `Params` class can be a `DynamicsParams` instance or a sequence of `DynamicsParams`.
- The `n_steps` parameter has moved from the dynamics parameters to the main `Params` class.
- `fluorophore_halflife_mode` does not have a default anymore.
- `fluorophore_halflife_var` does not have a default anymore.
- Pipeline steps have been refactored to work with the new parameter organisation.
- Existing scripts have been updated to function as previously post the refactor.